### PR TITLE
Thread safety fixes in StructureTemplateOptimizer

### DIFF
--- a/common/src/main/java/telepathicgrunt/structure_layout_optimizer/utils/StructureTemplateOptimizer.java
+++ b/common/src/main/java/telepathicgrunt/structure_layout_optimizer/utils/StructureTemplateOptimizer.java
@@ -1,5 +1,6 @@
 package telepathicgrunt.structure_layout_optimizer.utils;
 
+import it.unimi.dsi.fastutil.objects.Object2BooleanMaps;
 import it.unimi.dsi.fastutil.objects.Object2BooleanOpenHashMap;
 import net.minecraft.core.BlockPos;
 import net.minecraft.world.level.ServerLevelAccessor;
@@ -19,7 +20,7 @@ import java.util.Map;
 
 public class StructureTemplateOptimizer {
 
-    private static final Map<StructureProcessor, Boolean> FINALIZE_PROCESSING_PROCESSORS = new Object2BooleanOpenHashMap<>();
+    private static final Map<StructureProcessor, Boolean> FINALIZE_PROCESSING_PROCESSORS = Object2BooleanMaps.synchronize(new Object2BooleanOpenHashMap<>());
     private static final String FINALIZE_PROCESSING_METHOD_NAME = PlatformService.INSTANCE.getFinalizeProcessingMethodName();
 
     public static @NotNull List<StructureTemplate.StructureBlockInfo> getStructureBlockInfosInBounds(StructureTemplate.Palette instance, BlockPos offset, StructurePlaceSettings structurePlaceSettings) {


### PR DESCRIPTION
This PR synchronizes `FINALIZE_PROCESSING_PROCESSORS`, making it safe to execute `structure_starts` in parallel. 